### PR TITLE
Functional test build will be red if the tests fail

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -4,4 +4,11 @@ echo "The env is $1 $2 - in run-docker.sh"
 docker run -v /var/go/.m2:/root/.m2:rw -v $PWD:/gauge -e ENV=$1 -e TAGS=$2 -i bharatak/docker-gauge-chromedriver:chromedriver-2.34 -- sh run.sh
 #Hack. The html-report executable is symlinked as a root user.  
 #so, removing it so that the artifact is accessible from gocd server
+rc=$?
+if [[ $rc != 0 ]]; then
+	rm -f bahmni-gauge-default/reports/html-report/html-report
+	echo "The build is failed"
+	exit $rc; 
+fi
 rm -f bahmni-gauge-default/reports/html-report/html-report
+echo "The build is successful"


### PR DESCRIPTION
This PR captures the return code from the underlying docker container and return it to the gocd triggered process so that the build is treated as RED.